### PR TITLE
Fix doc for data invariant & remove tuple header

### DIFF
--- a/src/util/invariant.h
+++ b/src/util/invariant.h
@@ -12,7 +12,6 @@ Author: Martin Brain, martin.brain@diffblue.com
 #include <cstdlib>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 #include <type_traits>
 
 /*
@@ -376,7 +375,7 @@ invariant_violated_string(
 
 // This condition should be used to document that assumptions that are
 // made on goto_functions, goto_programs, exprts, etc. being well formed.
-// "The data structure is corrupt or malformed"
+// "The data structure is not corrupt or malformed"
 #define DATA_INVARIANT2(CONDITION, REASON) INVARIANT2(CONDITION, REASON)
 #define DATA_INVARIANT3(CONDITION, REASON, DIAGNOSTICS)                        \
   INVARIANT3(CONDITION, REASON, DIAGNOSTICS)


### PR DESCRIPTION
Inconsistency in final "summary statement" for data invariant 
• TLDR:
For data-invariant the statement was:
"The data structure is corrupt or malformed"  
Amended this to:
"The data structure is _not_ corrupt or malformed"

Also - <tuple> header no longer needed. 


*More info:*
e.g 
• precondition 
"The design of the system means that the arguments to this method
 will always meet this condition".  
(positive assertion)
• postcondition
"The implementation of this method means that the condition will hold". 
(positive assertion)
• check-return
"The contract of the previous method call means the following condition holds".
(positive assertion)

For data-invariant the statement was:
"The data structure is corrupt or malformed"  
(incorrect negative assertion)

Amended this to:
"The data structure is _not_ corrupt or malformed"